### PR TITLE
Fix dark mode contrast in Config Builder TOML preview

### DIFF
--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -87,3 +87,8 @@ body {
   padding: 1rem 0;
   margin: 0;
 }
+
+/* Config builder TOML preview: use Shiki dark tokens in dark mode */
+.dark .toml-preview pre.shiki span {
+  color: var(--shiki-dark) !important;
+}


### PR DESCRIPTION
Apply Shiki dark token color overrides in the Config Builder preview so TOML syntax remains readable in dark mode while preserving the transparent code block background.

### Before
<img width="654" height="291" alt="image" src="https://github.com/user-attachments/assets/203fafb2-c232-4b3d-a522-970b560bd52f" />

### After
<img width="655" height="293" alt="image" src="https://github.com/user-attachments/assets/c5884e1f-a29a-4a22-946d-0c30a3389035" />
