### PR TITLE
Add watch_debounce configuration and fix access event restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ max_memory = "512M"                 # restart when memory exceeds this (supports
 # File watching
 watch = true                        # or a path like "./src"
 watch_ignore = ["node_modules", ".git"]
+watch_debounce = 500                # ms before restart after file changes (default: 500)
 
 # Dependencies and groups
 depends_on = ["db", "cache"]        # start after these processes are running

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,7 @@ pub struct ProcessConfig {
     pub stop_exit_codes: Option<Vec<i32>>,
     pub watch: Option<Watch>,
     pub watch_ignore: Option<Vec<String>>,
+    pub watch_debounce: Option<u64>,
     pub depends_on: Option<Vec<String>>,
     pub restart: Option<RestartPolicy>,
     pub group: Option<String>,
@@ -115,6 +116,7 @@ struct RawProcessConfig {
     stop_exit_codes: Option<Vec<i32>>,
     watch: Option<Watch>,
     watch_ignore: Option<Vec<String>>,
+    watch_debounce: Option<u64>,
     depends_on: Option<Vec<String>>,
     restart: Option<RestartPolicy>,
     group: Option<String>,
@@ -199,6 +201,7 @@ pub fn parse_config(content: &str) -> Result<HashMap<String, ProcessConfig>, Con
                 stop_exit_codes: raw.stop_exit_codes,
                 watch: raw.watch,
                 watch_ignore: raw.watch_ignore,
+                watch_debounce: raw.watch_debounce,
                 depends_on: raw.depends_on,
                 restart: raw.restart,
                 group: raw.group,
@@ -238,6 +241,7 @@ min_uptime = 1000
 stop_exit_codes = [0, 143]
 watch = true
 watch_ignore = ["node_modules", ".git"]
+watch_debounce = 750
 depends_on = ["db"]
 restart = "on_failure"
 group = "backend"
@@ -275,6 +279,7 @@ DATABASE_URL = "postgres://prod/db"
             web.watch_ignore,
             Some(vec!["node_modules".to_string(), ".git".to_string()])
         );
+        assert_eq!(web.watch_debounce, Some(750));
         assert_eq!(web.depends_on, Some(vec!["db".to_string()]));
         assert_eq!(web.restart, Some(RestartPolicy::OnFailure));
         assert_eq!(web.group.as_deref(), Some("backend"));
@@ -492,6 +497,7 @@ DATABASE_URL = "postgres://staging/db"
             stop_exit_codes: None,
             watch: None,
             watch_ignore: None,
+            watch_debounce: None,
             depends_on: None,
             restart: None,
             group: None,

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -276,6 +276,7 @@ mod tests {
             stop_exit_codes: None,
             watch: None,
             watch_ignore: None,
+            watch_debounce: None,
             depends_on: deps.map(|v| v.into_iter().map(|s| s.to_string()).collect()),
             restart: None,
             group: None,

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1423,6 +1423,7 @@ mod tests {
             stop_exit_codes: None,
             watch: None,
             watch_ignore: None,
+            watch_debounce: None,
             depends_on: None,
             restart: None,
             group: None,

--- a/src/process.rs
+++ b/src/process.rs
@@ -829,6 +829,7 @@ mod tests {
             stop_exit_codes: None,
             watch: None,
             watch_ignore: None,
+            watch_debounce: None,
             depends_on: None,
             restart,
             group: None,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -227,6 +227,7 @@ mod tests {
                 stop_exit_codes: None,
                 watch: None,
                 watch_ignore: None,
+                watch_debounce: None,
                 depends_on: None,
                 restart: None,
                 group: None,

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -2,6 +2,7 @@ use crate::config::{ProcessConfig, Watch};
 use crate::paths::Paths;
 use crate::process::{self, ProcessTable};
 use crate::protocol::ProcessStatus;
+use notify::event::EventKind;
 use notify::{RecursiveMode, Watcher};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -50,6 +51,14 @@ fn should_ignore(path: &std::path::Path, ignore_patterns: &[String]) -> bool {
     }
     false
 }
+
+fn should_restart_for_event_kind(kind: &EventKind) -> bool {
+    matches!(
+        kind,
+        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_) | EventKind::Any
+    )
+}
+
 pub fn spawn_watcher(
     name: String,
     config: ProcessConfig,
@@ -113,7 +122,11 @@ pub fn spawn_watcher(
             let mut has_relevant = first_event
                 .paths
                 .iter()
-                .any(|p| !p.is_dir() && !should_ignore(p, &ignore_patterns));
+                .any(|p| {
+                    should_restart_for_event_kind(&first_event.kind)
+                        && !p.is_dir()
+                        && !should_ignore(p, &ignore_patterns)
+                });
 
             // Debounce: wait configured duration, drain any further events
             tokio::select! {
@@ -129,7 +142,10 @@ pub fn spawn_watcher(
             while let Ok(event) = rx.try_recv() {
                 if !has_relevant {
                     for path in &event.paths {
-                        if !path.is_dir() && !should_ignore(path, &ignore_patterns) {
+                        if should_restart_for_event_kind(&event.kind)
+                            && !path.is_dir()
+                            && !should_ignore(path, &ignore_patterns)
+                        {
                             has_relevant = true;
                             break;
                         }
@@ -350,5 +366,16 @@ mod tests {
 
         config.watch_debounce = Some(1200);
         assert_eq!(debounce_duration(&config), Duration::from_millis(1200));
+    }
+
+    #[test]
+    fn test_should_restart_for_event_kind() {
+        use notify::event::{AccessKind, CreateKind, ModifyKind, RemoveKind};
+
+        assert!(should_restart_for_event_kind(&EventKind::Create(CreateKind::Any)));
+        assert!(should_restart_for_event_kind(&EventKind::Modify(ModifyKind::Any)));
+        assert!(should_restart_for_event_kind(&EventKind::Remove(RemoveKind::Any)));
+        assert!(should_restart_for_event_kind(&EventKind::Any));
+        assert!(!should_restart_for_event_kind(&EventKind::Access(AccessKind::Any)));
     }
 }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -7,7 +7,14 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{RwLock, watch};
-pub const DEBOUNCE_DURATION: Duration = Duration::from_millis(500);
+pub const DEFAULT_DEBOUNCE_DURATION: Duration = Duration::from_millis(500);
+
+pub fn debounce_duration(config: &ProcessConfig) -> Duration {
+    config
+        .watch_debounce
+        .map(Duration::from_millis)
+        .unwrap_or(DEFAULT_DEBOUNCE_DURATION)
+}
 pub fn resolve_watch_path(config: &ProcessConfig) -> Option<PathBuf> {
     match config.watch.as_ref()? {
         Watch::Enabled(false) => None,
@@ -54,6 +61,7 @@ pub fn spawn_watcher(
         return;
     };
 
+    let watch_debounce_duration = debounce_duration(&config);
     let ignore_patterns: Vec<String> = config.watch_ignore.clone().unwrap_or_default();
 
     tokio::spawn(async move {
@@ -107,9 +115,9 @@ pub fn spawn_watcher(
                 .iter()
                 .any(|p| !p.is_dir() && !should_ignore(p, &ignore_patterns));
 
-            // Debounce: wait DEBOUNCE_DURATION, drain any further events
+            // Debounce: wait configured duration, drain any further events
             tokio::select! {
-                _ = tokio::time::sleep(DEBOUNCE_DURATION) => {}
+                _ = tokio::time::sleep(watch_debounce_duration) => {}
                 _ = shutdown_rx.changed() => {
                     if *shutdown_rx.borrow() {
                         return;
@@ -225,6 +233,7 @@ mod tests {
             stop_exit_codes: None,
             watch: None,
             watch_ignore: None,
+            watch_debounce: None,
             depends_on: None,
             restart: None,
             group: None,
@@ -332,5 +341,14 @@ mod tests {
                 "logs".to_string()
             ]
         ));
+    }
+
+    #[test]
+    fn test_debounce_duration_default_and_custom() {
+        let mut config = base_config();
+        assert_eq!(debounce_duration(&config), DEFAULT_DEBOUNCE_DURATION);
+
+        config.watch_debounce = Some(1200);
+        assert_eq!(debounce_duration(&config), Duration::from_millis(1200));
     }
 }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -119,14 +119,11 @@ pub fn spawn_watcher(
             // Skip directory paths — on macOS, FSEvents fires events for parent
             // directories when child files change, and those parent paths may not
             // contain the ignored component.
-            let mut has_relevant = first_event
-                .paths
-                .iter()
-                .any(|p| {
-                    should_restart_for_event_kind(&first_event.kind)
-                        && !p.is_dir()
-                        && !should_ignore(p, &ignore_patterns)
-                });
+            let mut has_relevant = first_event.paths.iter().any(|p| {
+                should_restart_for_event_kind(&first_event.kind)
+                    && !p.is_dir()
+                    && !should_ignore(p, &ignore_patterns)
+            });
 
             // Debounce: wait configured duration, drain any further events
             tokio::select! {
@@ -372,10 +369,18 @@ mod tests {
     fn test_should_restart_for_event_kind() {
         use notify::event::{AccessKind, CreateKind, ModifyKind, RemoveKind};
 
-        assert!(should_restart_for_event_kind(&EventKind::Create(CreateKind::Any)));
-        assert!(should_restart_for_event_kind(&EventKind::Modify(ModifyKind::Any)));
-        assert!(should_restart_for_event_kind(&EventKind::Remove(RemoveKind::Any)));
+        assert!(should_restart_for_event_kind(&EventKind::Create(
+            CreateKind::Any
+        )));
+        assert!(should_restart_for_event_kind(&EventKind::Modify(
+            ModifyKind::Any
+        )));
+        assert!(should_restart_for_event_kind(&EventKind::Remove(
+            RemoveKind::Any
+        )));
         assert!(should_restart_for_event_kind(&EventKind::Any));
-        assert!(!should_restart_for_event_kind(&EventKind::Access(AccessKind::Any)));
+        assert!(!should_restart_for_event_kind(&EventKind::Access(
+            AccessKind::Any
+        )));
     }
 }

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -25,6 +25,7 @@ fn test_config(command: &str) -> ProcessConfig {
         stop_exit_codes: None,
         watch: None,
         watch_ignore: None,
+        watch_debounce: None,
         depends_on: None,
         restart: None,
         group: None,
@@ -4157,6 +4158,76 @@ async fn test_watch_debounce_rapid_changes_trigger_one_restart() {
         final_restarts, 1,
         "rapid file changes should debounce into a single restart, got {} restarts",
         final_restarts
+    );
+
+    send_raw_request(&paths, &Request::Kill).await;
+    let _ = handle.await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_watch_debounce_respects_custom_duration() {
+    let dir = TempDir::new().unwrap();
+    let paths = Paths::with_base(dir.path().to_path_buf());
+    let handle = start_test_daemon(&paths).await;
+
+    let watch_dir = dir.path().join("custom_debounce_src");
+    std::fs::create_dir_all(&watch_dir).unwrap();
+    std::fs::write(watch_dir.join("file.txt"), "v0").unwrap();
+
+    let mut config = test_config("sleep 999");
+    config.watch = Some(Watch::Path(watch_dir.to_string_lossy().to_string()));
+    config.watch_debounce = Some(1500);
+    config.restart = Some(RestartPolicy::Never);
+
+    let mut configs = HashMap::new();
+    configs.insert("custom-debounce".to_string(), config);
+
+    let resp = send_raw_request(
+        &paths,
+        &Request::Start {
+            configs,
+            names: None,
+            env: None,
+            wait: false,
+            path: None,
+        },
+    )
+    .await;
+    assert!(matches!(resp, Response::Success { .. }));
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    std::fs::write(watch_dir.join("file.txt"), "v1").unwrap();
+
+    tokio::time::sleep(Duration::from_millis(700)).await;
+    let list_resp = send_raw_request(&paths, &Request::List).await;
+    if let Response::ProcessList { processes } = list_resp {
+        let p = processes
+            .iter()
+            .find(|p| p.name == "custom-debounce")
+            .unwrap();
+        assert_eq!(p.restarts, 0, "restart should wait for custom debounce");
+    } else {
+        panic!("expected process list");
+    }
+
+    let mut restarted = false;
+    for _ in 0..10 {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let list_resp = send_raw_request(&paths, &Request::List).await;
+        if let Response::ProcessList { processes } = list_resp {
+            let p = processes
+                .iter()
+                .find(|p| p.name == "custom-debounce")
+                .unwrap();
+            if p.restarts >= 1 {
+                restarted = true;
+                break;
+            }
+        }
+    }
+    assert!(
+        restarted,
+        "custom debounce restart should eventually happen"
     );
 
     send_raw_request(&paths, &Request::Kill).await;


### PR DESCRIPTION
This pull request adds support for configuring a custom debounce duration for file watching, allowing users to control how long the system waits after file changes before restarting a process.

Alongside this, the implementation ensures only relevant file events trigger restarts and updates the configuration parsing, documentation, and tests to support the new feature.
