### PR TITLE
Add support for Alpine

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,7 +10,7 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program


### PR DESCRIPTION
This pull request updates the supported build targets in the `dist-workspace.toml` configuration file. The change adds support for the `musl` variants of both `aarch64` and `x86_64` Linux targets, expanding the platforms on which the app can be built and distributed.

Platform support:

* Added `aarch64-unknown-linux-musl` and `x86_64-unknown-linux-musl` to the `targets` list in `dist-workspace.toml` to enable building for statically linked Linux binaries using `musl`.